### PR TITLE
macOS version rather than the darwin version

### DIFF
--- a/openAutomation.py
+++ b/openAutomation.py
@@ -47,7 +47,7 @@ def openFile(directory, filename) :
 # verifies system is on mac os
 def validateSystem() :
     system = platform.platform()
-    if 'darwin' not in system.lower() :
+    if 'macos' not in system.lower() :
         print('system: {}'.format(system))
         print("Sorry, this script is only supported on mac!")
         exit(1)


### PR DESCRIPTION
#Changed in version 3.8: On macOS, the function now uses mac_ver(), if it returns a non-empty release string, to get the macOS version rather than the darwin version.

>>> import platform
>>> platform.platform()
'macOS-13.2.1-x86_64-i386-64bit'